### PR TITLE
Default to using http://sharedcount.com for counts

### DIFF
--- a/test/socialcount_test.js
+++ b/test/socialcount_test.js
@@ -115,6 +115,7 @@
 			$test = $( '#test' ),
 			gplusLabel = $test.find( '.googleplus .count' ).html();
 
+		SocialCount.useSharedCountService = false;
 		SocialCount.cache['http://www.google.com/'] = dfd.promise();
 
 		SocialCount.getCounts( $test, 'http://www.google.com/' ).done(function() {
@@ -139,6 +140,7 @@
 			$test = $( '#test' ),
 			gplusLabel = $test.find( '.googleplus .count' ).html();
 
+		SocialCount.useSharedCountService = false;
 		SocialCount.cache['http://www.google.com/'] = dfd.promise();
 
 		SocialCount.getCounts( $test, 'http://www.google.com/' ).done(function() {
@@ -156,6 +158,21 @@
 				'googleplus': SocialCount.minCount - 1
 			});
 		}, 50 );
+	});
+
+	asyncTest( 'Test can use SharedCount API for counts', 3, function() {
+		var $test = $( '#test' );
+
+		SocialCount.useSharedCountService = true;
+		SocialCount.cache['http://www.google.com/'] = null;
+
+		SocialCount.getCounts( $test, 'http://www.google.com/' ).done(function() {
+			strictEqual( $test.find( '.twitter .count' ).html(), '11M' );
+			strictEqual( $test.find( '.facebook .count' ).html(), '5M' );
+			strictEqual( $test.find( '.googleplus .count' ).html(), '1M' );
+
+			start();
+		});
 	});
 
 	module('testInitializeNoUrl', {


### PR DESCRIPTION
Hello, instead of using the included PHP script I think SocialCount could benefit by using a 3rd party service (Shared Count) to query for shares across different social networks.

I've added a boolean that defaults SocialCount to use the Shared Count API however I've left the code to use the included PHP script in. Alternatively, the PHP script can be pulled from the plugin entirely to trim down the size but I'll leave that decision up to you guys.

--Xiao
