### PR TITLE
Locale conflict with facebook

### DIFF
--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -67,7 +67,7 @@
 			twitter: '.twitter',
 			googleplus: '.googleplus'
 		},
-		locale: doc.documentElement ? ( doc.documentElement.lang || '' ) : '',
+		locale: doc.documentElement ? ( doc.documentElement.lang || '' ).replace('-', '_') : '',
 		googleplusTooltip: 'table.gc-bubbleDefault',
 		scriptSrcRegex: /socialcount[\w.]*.js/i,
 		plugins: {

--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -168,6 +168,9 @@
 			} else {
 				classes.push( SocialCount.classes.activateOnHover );
 			}
+			if ($el.data('locale')) {
+				SocialCount.locale = $el.data('locale');
+			}
 			if( SocialCount.locale ) {
 				classes.push( SocialCount.locale );
 			}

--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -152,7 +152,8 @@
 				isSmall = SocialCount.isSmallSize( $el ),
 				url = SocialCount.getUrl( $el ),
 				initPlugins = SocialCount.plugins.init,
-				countsEnabled = SocialCount.isCountsEnabled( $el );
+				countsEnabled = SocialCount.isCountsEnabled( $el ),
+				locale = $el.data('locale');
 
 			if( SocialCount.isGradeA ) {
 				classes.push( SocialCount.classes.gradeA );
@@ -168,8 +169,8 @@
 			} else {
 				classes.push( SocialCount.classes.activateOnHover );
 			}
-			if (locale = $el.data('locale')) {
-				SocialCount.locale = locale != "none" ? locale : '';
+			if (locale) {
+				SocialCount.locale = locale !== "none" ? locale : '';
 			}
 			if( SocialCount.locale ) {
 				classes.push( SocialCount.locale );

--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -168,8 +168,8 @@
 			} else {
 				classes.push( SocialCount.classes.activateOnHover );
 			}
-			if ($el.data('locale')) {
-				SocialCount.locale = $el.data('locale');
+			if (locale = $el.data('locale')) {
+				SocialCount.locale = locale != "none" ? locale : '';
 			}
 			if( SocialCount.locale ) {
 				classes.push( SocialCount.locale );


### PR DESCRIPTION
This fix various issues with the locale parameter of facebook.
1. replace "-" with "_" in the locale string to be compatible with facebook
2. Add a "data-locale" attribute to override the automatic locale detection
3. Add the possibility to pass "none" to the data-locale attribute to disable it

Related issue: #29
