### PR TITLE
Fix url encoding if it contains parameters

### DIFF
--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -293,14 +293,14 @@
 				var shareText = SocialCount.getShareText( $el );
 
 				bind( $el.find( SocialCount.selectors.facebook + ' a' ),
-					'<iframe src="//www.facebook.com/plugins/like.php?href=' + encodeURI( url ) +
+					'<iframe src="//www.facebook.com/plugins/like.php?href=' + encodeURIComponent( url ) +
 						( SocialCount.locale ? '&locale=' + SocialCount.locale : '' ) +
 						'&amp;send=false&amp;layout=button_count&amp;width=100&amp;show_faces=true&amp;action=' + facebookAction +
 						'&amp;colorscheme=light&amp;font=arial&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowTransparency="true"></iframe>' );
 
 				bind( $el.find( SocialCount.selectors.twitter + ' a' ),
 					'<a href="https://twitter.com/share" class="twitter-share-button"' +
-						' data-url="' + encodeURI( url ) + '"' +
+						' data-url="' + encodeURIComponent( url ) + '"' +
 						( shareText ? ' data-text="' + shareText + '"': '' ) +
 						' data-count="none" data-dnt="true">Tweet</a>',
 					'//platform.twitter.com/widgets.js' );


### PR DESCRIPTION
The url was not encoded enough if it contains some parameters.
For instance `mysite.com/?post_type=page&post_id=24` would create a faceook like on `mysite.com/?post_type=page`.

I changed encodeURI to encodeURIComponent and it fixed my issue.
