### PR TITLE
Fixes issue 45: “Twitter not picking up URL”

### DIFF
--- a/src/socialcount.js
+++ b/src/socialcount.js
@@ -310,7 +310,7 @@
 
 				bind( $el.find( SocialCount.selectors.twitter + ' a' ),
 					'<a href="https://twitter.com/share" class="twitter-share-button"' +
-						' data-url="' + encodeURIComponent( url ) + '"' +
+						' data-url="' + url + '"' +
 						( shareText ? ' data-text="' + shareText + '"': '' ) +
 						' data-count="none" data-dnt="true">Tweet</a>',
 					'//platform.twitter.com/widgets.js' );


### PR DESCRIPTION
Patch for https://github.com/filamentgroup/SocialCount/issues/45

Seems like twitter doesn’t like the URL to be encoded, so I removed encodeURIComponent – Not sure if this is the best solution but it works for now.
