### PR TITLE
Make available via Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ SocialCount is a small jQuery plugin for progressively enhanced, lazy loaded, mo
 
 ## Getting Started
 
-The following archive contains both minified (`socialcount.min.js`+`socialcount.min.css`) and unminified (`socialcount.js`+`socialcount.css`) versions of the JS and CSS required to use SocialCount.
+Install via Bower:
+
+```
+bower install --save socialcount
+```
+
+Alternatively, the following archive contains both minified (`socialcount.min.js`+`socialcount.min.css`) and unminified (`socialcount.js`+`socialcount.css`) versions of the JS and CSS required to use SocialCount.
 
 By default, the social networking icons are not included. However, SocialCount publishes a version that does include the social networking icons: Use the regular `socialcount.js` with `socialcount-with-icons.css` or `socialcount-with-icons.min.css` and the included SD and HD image sprites.
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "socialcount",
+  "description": "Progressively enhanced, lazy loaded, mobile friendly Social Networking widgets",
+  "version": "0.1.8",
+  "keywords": [
+    "social",
+    "share",
+    "like",
+    "follow",
+    "facebook",
+    "twitter",
+    "google"
+  ],
+  "authors": [
+    {
+      "name": "zachleat",
+      "email": "zach@filamentgroup.com",
+      "homepage": "http://www.filamentgroup.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/filamentgroup/SocialCount.git"
+  },
+  "main": [
+    "dist/socialcount.js",
+    "dist/socialcount.css"
+  ],
+  "ignore": [
+    "node_modules",
+    ".sass-cache"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
Having people install SocialCount by downloading a zipped folder is not desirable when package managers exist to keep people's dependencies up to date. This PR does everything required to make the package available on Bower except for actually registering the package.

Once this PR is merged you can register the package as `socialcount` by following the [instructions here](http://bower.io/docs/creating-packages/#register) but it's as simple as:

```
bower register socialcount https://github.com/filamentgroup/SocialCount.git
```