### PR TITLE
Fix for Twitter API timeouts

### DIFF
--- a/src/service/SocialCount.php
+++ b/src/service/SocialCount.php
@@ -14,7 +14,7 @@ class Twitter implements SocialNetwork
 
 	public function getShareCount($url)
 	{
-		$contents = @file_get_contents('http://urls.api.twitter.com/1/urls/count.json?url=' . $url);
+		$contents = @file_get_contents('https://cdn.syndication.twitter.com/widgets/tweetbutton/count.json?url=' . $url);
 		if($contents) {
 			return json_decode($contents)->count;
 		} else {


### PR DESCRIPTION
Since September 24th I've noticed an increase in timeouts for urls.api.twitter.com that can be solved by using the updated URL.