### PR TITLE
Specify Graph API version

### DIFF
--- a/dist/service/SocialCount.php
+++ b/dist/service/SocialCount.php
@@ -13,7 +13,7 @@ class Facebook implements SocialNetwork {
 
 	public function getShareCount($url)
 	{
-		$contents = @file_get_contents("http://graph.facebook.com/fql?q=SELECT%20url,%20total_count%20FROM%20link_stat%20WHERE%20url='".$url."'");
+		$contents = @file_get_contents("http://graph.facebook.com/v2.11/fql?q=SELECT%20url,%20total_count%20FROM%20link_stat%20WHERE%20url='".$url."'");
 		if($contents) {
 			$json = json_decode($contents);
 			return isset($json->data[0]->total_count) ? $json->data[0]->total_count : 0;


### PR DESCRIPTION
This plugin calls Facebook's Graph API without specifying a version number:

https://github.com/filamentgroup/SocialCount/blob/9a4bf84cd97f95c0e0a7f36bdff6188319d3ff1e/dist/service/SocialCount.php#L16

Facebook say:

> **What happens if I don't specify a version for an API?**
>
> We refer to this as an **unversioned** call. An unversioned call will default to the oldest available version of the API. Consider this hypothetical life cycle of API versions:
> 
> ![image](https://user-images.githubusercontent.com/1324225/32659190-2e208a88-c626-11e7-97e4-aa1362093737.png)
> 
> An unversioned call will always point to the oldest version still available at the top of the chart. This is currently v2.1, but after two years it'll be v2.2, then v2.3, etc.
> 
> Because of this, our recommendation is to always specify versions when making calls, where possible.

The latest Graph API version is v2.11, released [this week](https://developers.facebook.com/docs/graph-api/changelog) and v2.1 has been [EOL since 2016-10-30](https://developers.facebook.com/docs/graph-api/changelog/archive).

